### PR TITLE
GraphQL Schedule page and created new shared Amplify environment for everyone

### DIFF
--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -55,70 +55,16 @@
             }
         }
     },
-    "noah": {
+    "shared": {
         "awscloudformation": {
-            "AuthRoleName": "amplify-betteruni-noah-135015-authRole",
-            "UnauthRoleArn": "arn:aws:iam::045312015851:role/amplify-betteruni-noah-135015-unauthRole",
-            "AuthRoleArn": "arn:aws:iam::045312015851:role/amplify-betteruni-noah-135015-authRole",
+            "AuthRoleName": "amplify-betteruni-shared-113204-authRole",
+            "UnauthRoleArn": "arn:aws:iam::045312015851:role/amplify-betteruni-shared-113204-unauthRole",
+            "AuthRoleArn": "arn:aws:iam::045312015851:role/amplify-betteruni-shared-113204-authRole",
             "Region": "us-east-1",
-            "DeploymentBucketName": "amplify-betteruni-noah-135015-deployment",
-            "UnauthRoleName": "amplify-betteruni-noah-135015-unauthRole",
-            "StackName": "amplify-betteruni-noah-135015",
-            "StackId": "arn:aws:cloudformation:us-east-1:045312015851:stack/amplify-betteruni-noah-135015/12f825f0-782f-11ea-b6af-12f8925a37c4",
-            "AmplifyAppId": "d10zhgeiihhv0k"
-        },
-        "categories": {
-            "auth": {
-                "betteruni4fc5aa3b4fc5aa3b": {}
-            }
-        }
-    },
-    "ariela": {
-        "awscloudformation": {
-            "AuthRoleName": "amplify-betteruni-ariela-142012-authRole",
-            "UnauthRoleArn": "arn:aws:iam::045312015851:role/amplify-betteruni-ariela-142012-unauthRole",
-            "AuthRoleArn": "arn:aws:iam::045312015851:role/amplify-betteruni-ariela-142012-authRole",
-            "Region": "us-east-1",
-            "DeploymentBucketName": "amplify-betteruni-ariela-142012-deployment",
-            "UnauthRoleName": "amplify-betteruni-ariela-142012-unauthRole",
-            "StackName": "amplify-betteruni-ariela-142012",
-            "StackId": "arn:aws:cloudformation:us-east-1:045312015851:stack/amplify-betteruni-ariela-142012/4256a020-7833-11ea-a755-0a7396047ff3",
-            "AmplifyAppId": "d10zhgeiihhv0k"
-        },
-        "categories": {
-            "auth": {
-                "betteruni4fc5aa3b4fc5aa3b": {}
-            }
-        }
-    },
-    "davisdev": {
-        "awscloudformation": {
-            "AuthRoleName": "amplify-betteruni-davisdev-144130-authRole",
-            "UnauthRoleArn": "arn:aws:iam::045312015851:role/amplify-betteruni-davisdev-144130-unauthRole",
-            "AuthRoleArn": "arn:aws:iam::045312015851:role/amplify-betteruni-davisdev-144130-authRole",
-            "Region": "us-east-1",
-            "DeploymentBucketName": "amplify-betteruni-davisdev-144130-deployment",
-            "UnauthRoleName": "amplify-betteruni-davisdev-144130-unauthRole",
-            "StackName": "amplify-betteruni-davisdev-144130",
-            "StackId": "arn:aws:cloudformation:us-east-1:045312015851:stack/amplify-betteruni-davisdev-144130/3bf48870-7836-11ea-add1-0e28043c5c55",
-            "AmplifyAppId": "d10zhgeiihhv0k"
-        },
-        "categories": {
-            "auth": {
-                "betteruni4fc5aa3b4fc5aa3b": {}
-            }
-        }
-    },
-    "richard": {
-        "awscloudformation": {
-            "AuthRoleName": "amplify-betteruni-richard-145416-authRole",
-            "UnauthRoleArn": "arn:aws:iam::045312015851:role/amplify-betteruni-richard-145416-unauthRole",
-            "AuthRoleArn": "arn:aws:iam::045312015851:role/amplify-betteruni-richard-145416-authRole",
-            "Region": "us-east-1",
-            "DeploymentBucketName": "amplify-betteruni-richard-145416-deployment",
-            "UnauthRoleName": "amplify-betteruni-richard-145416-unauthRole",
-            "StackName": "amplify-betteruni-richard-145416",
-            "StackId": "arn:aws:cloudformation:us-east-1:045312015851:stack/amplify-betteruni-richard-145416/04992af0-7838-11ea-bab5-0a3bc12b2732",
+            "DeploymentBucketName": "amplify-betteruni-shared-113204-deployment",
+            "UnauthRoleName": "amplify-betteruni-shared-113204-unauthRole",
+            "StackName": "amplify-betteruni-shared-113204",
+            "StackId": "arn:aws:cloudformation:us-east-1:045312015851:stack/amplify-betteruni-shared-113204/18f04e60-7e65-11ea-b3e5-0ad6b76236b1",
             "AmplifyAppId": "d10zhgeiihhv0k"
         },
         "categories": {

--- a/src/components/Category/Category.js
+++ b/src/components/Category/Category.js
@@ -28,7 +28,7 @@ export default function Category(props) {
   const classes = useStyles();
 
   return (
-    <TableRow className="category" hover key={props.category.title}>
+    <TableRow className="category" hover key={props.category.name}>
       <TableCell className={classes.cell}>
         <Box
           className={classes.nameContainer}
@@ -38,7 +38,7 @@ export default function Category(props) {
           padding={1}
         >
           <Typography className={classes.text}>
-            {props.category.title}
+            {props.category.name}
           </Typography>
         </Box>
       </TableCell>

--- a/src/components/CategoryList/CategoryList.js
+++ b/src/components/CategoryList/CategoryList.js
@@ -33,7 +33,7 @@ export default function CategoryList(props) {
           <Table className={classes.inner}>
             <TableBody>
               {props.categories.map(category => (
-                <Category key={category.title} category={category} />
+                <Category key={category.name} category={category} />
               ))}
             </TableBody>
           </Table>

--- a/src/components/HomeInfoList/HomeInfoList.js
+++ b/src/components/HomeInfoList/HomeInfoList.js
@@ -12,7 +12,6 @@ import {
 } from "@material-ui/core";
 import { Link } from "react-router-dom";
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
-import "./HomeInfoList.css";
 
 const useStyles = makeStyles(theme => ({
   root: {},

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -3636,6 +3636,100 @@
         "possibleTypes" : null
       }, {
         "kind" : "INPUT_OBJECT",
+        "name" : "ModelIntInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "ne",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "eq",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "le",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "lt",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "ge",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "gt",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "between",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "attributeExists",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "attributeType",
+          "description" : null,
+          "type" : {
+            "kind" : "ENUM",
+            "name" : "ModelAttributeTypes",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
         "name" : "ModelFloatInput",
         "description" : null,
         "fields" : null,
@@ -3734,100 +3828,6 @@
         "description" : "Built-in Float",
         "fields" : null,
         "inputFields" : null,
-        "interfaces" : null,
-        "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "INPUT_OBJECT",
-        "name" : "ModelIntInput",
-        "description" : null,
-        "fields" : null,
-        "inputFields" : [ {
-          "name" : "ne",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "eq",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "le",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "lt",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "ge",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "gt",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Int",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "between",
-          "description" : null,
-          "type" : {
-            "kind" : "LIST",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "Int",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "attributeExists",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Boolean",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "attributeType",
-          "description" : null,
-          "type" : {
-            "kind" : "ENUM",
-            "name" : "ModelAttributeTypes",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        } ],
         "interfaces" : null,
         "enumValues" : null,
         "possibleTypes" : null
@@ -4673,6 +4673,23 @@
         "onFragment" : false,
         "onField" : false
       }, {
+        "name" : "deprecated",
+        "description" : null,
+        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
+        "args" : [ {
+          "name" : "reason",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : "\"No longer supported\""
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
         "name" : "aws_publish",
         "description" : "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
         "locations" : [ "FIELD_DEFINITION" ],
@@ -4710,23 +4727,6 @@
             }
           },
           "defaultValue" : null
-        } ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "deprecated",
-        "description" : null,
-        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
-        "args" : [ {
-          "name" : "reason",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
-            "ofType" : null
-          },
-          "defaultValue" : "\"No longer supported\""
         } ],
         "onOperation" : false,
         "onFragment" : false,

--- a/src/pages/SchedulePage/SchedulePage.js
+++ b/src/pages/SchedulePage/SchedulePage.js
@@ -1,5 +1,7 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { UserContext } from "../../UserContext";
+import { API, graphqlOperation } from "aws-amplify";
+import { listAdvisingCategorys as ListAdvisingCategories } from "../../graphql/queries";
 import AdvisorList from "../../components/AdvisorList/AdvisorList";
 import CategoryList from "../../components/CategoryList/CategoryList";
 
@@ -42,27 +44,6 @@ const advisors = [
   }
 ];
 
-const categories = [
-  {
-    title: "CST Advising"
-  },
-  {
-    title: "Counseling"
-  },
-  {
-    title: "Career Center"
-  },
-  {
-    title: "Tutoring"
-  },
-  {
-    title: "Writing Center"
-  },
-  {
-    title: "Student Health Services"
-  }
-];
-
 export function SchedulePage() {
   /* 
     Will use UserContext to set UserContext provider data - this will update the current user's meeting data across all components
@@ -71,11 +52,25 @@ export function SchedulePage() {
   // eslint-disable-next-line no-unused-vars
   const user = useContext(UserContext);
 
+  const [advCats, setAdvCats] = useState([]);
+
+  useEffect(() => {
+    API.graphql(graphqlOperation(ListAdvisingCategories))
+      .then(res => {
+        console.log(res.data.listAdvisingCategorys.items);
+        const advCats = res.data.listAdvisingCategorys.items;
+        setAdvCats(advCats);
+      })
+      .catch(err => console.log(err));
+  }, []);
+
+  console.log("returnedAdvCats", advCats);
+
   return (
     <>
       <h1>Schedule page</h1>
       <p>This is the schedule page</p>
-      <CategoryList categories={categories} />
+      <CategoryList categories={advCats} />
       <AdvisorList advisors={advisors} />
     </>
   );

--- a/src/pages/SchedulePage/SchedulePage.js
+++ b/src/pages/SchedulePage/SchedulePage.js
@@ -57,14 +57,11 @@ export function SchedulePage() {
   useEffect(() => {
     API.graphql(graphqlOperation(ListAdvisingCategories))
       .then(res => {
-        console.log(res.data.listAdvisingCategorys.items);
         const advCats = res.data.listAdvisingCategorys.items;
         setAdvCats(advCats);
       })
       .catch(err => console.log(err));
   }, []);
-
-  console.log("returnedAdvCats", advCats);
 
   return (
     <>


### PR DESCRIPTION
Did a GraphQL demo for everyone, deleted individual Amplify environments, created one shared Amplify environment for everyone to use, added GraphQL code for advising categories to the Schedule page
- The new shared Amplify environment will let everyone have access to the same data in development, this avoids having to recreate the same data for 4 different developer environments