### PR TITLE
Fixed email verification from showing after sign in

### DIFF
--- a/amplify/backend/auth/betteruni4fc5aa3b4fc5aa3b/parameters.json
+++ b/amplify/backend/auth/betteruni4fc5aa3b4fc5aa3b/parameters.json
@@ -31,6 +31,7 @@
     ],
     "userpoolClientReadAttributes": [
         "email",
+        "email_verified",
         "custom:tuid",
         "custom:major",
         "custom:firstName",


### PR DESCRIPTION
The user's email is already verified by this point. Their email was verified after they confirmed the creation of their account using the Cognito code emailed to them in the account sign up process.